### PR TITLE
ci: build esp32-c3

### DIFF
--- a/esp32-rust/Dockerfile
+++ b/esp32-rust/Dockerfile
@@ -13,7 +13,8 @@ USER rust
 WORKDIR /home/rust
 
 COPY install-rust-toolchain.sh .
-RUN ./install-rust-toolchain.sh --extra-crates "ldproxy cargo-generate" --clear-cache "YES" --export-file /home/rust/export-rust.sh
+RUN ./install-rust-toolchain.sh --extra-crates "ldproxy cargo-generate" --clear-cache "YES" --export-file /home/rust/export-rust.sh \
+  && rm -rf rust-1.59.0.0-aarch64-unknown-linux-gnu*
 
 COPY entrypoint.sh /opt/esp/entrypoint.sh
 COPY motd /etc/motd
@@ -34,9 +35,16 @@ RUN sed -i -e 's!esp-13.0.0-20211203-aarch64-unknown-linux-gnu/!esp-13.0.0-20211
 
 RUN pip3 install esptool --user
 
-# Compile esp-idf-hal examples
 RUN . /opt/esp/entrypoint.sh \
-  && cd rust-project \
-  && cargo +esp build --example ledc-simple --release --target xtensa-esp32-espidf
+  && rustup default nightly \
+  && rustup component add rust-src --toolchain nightly-aarch64-unknown-linux-gnu
 
 COPY compile.sh /home/rust
+# Compile esp-idf-hal examples
+RUN . /opt/esp/entrypoint.sh \
+ && cd rust-project \
+ && export WOKWI_MCU="esp32-c3" \
+ && /home/rust/compile.sh \
+ && export WOKWI_MCU="esp32" \
+ && /home/rust/compile.sh \
+ && rm /home/rust/rust-project/build-out/project.bin

--- a/esp32-rust/compile.sh
+++ b/esp32-rust/compile.sh
@@ -1,6 +1,41 @@
 #!/bin/sh
 
-cd rust-project
-cat build-in/main.rs > examples/ledc-simple.rs && \
-cargo +esp build --example ledc-simple --release --target xtensa-esp32-espidf && \
-python3 -m esptool --chip esp32 elf2image --flash_size 4MB target/xtensa-esp32-espidf/release/examples/ledc-simple -o build-out/project.bin
+set -e
+
+case ${WOKWI_MCU} in
+    "esp32")
+      TOOLCHAIN="+esp"
+      TARGET="xtensa-esp32-espidf"
+      ;;
+    "esp32-s2")
+      TOOLCHAIN="+esp"
+      TARGET="xtensa-esp32s2-espidf"
+      ;;
+    "esp32-s3")
+      TOOLCHAIN="+esp"
+      TARGET="xtensa-esp32s3-espidf"
+      ;;
+    "esp32-c3")
+      TOOLCHAIN=""
+      TARGET="riscv32imc-esp-espidf"
+      ;;
+    *) # unknown
+      echo "Environment variable WOKWI_MCU not set."
+      echo "Available values esp32, esp32-s2, esp32-c3"
+      exit 1
+      ;;
+esac
+
+echo "Configuration of ${WOKWI_MCU}"
+echo " - TARGET    = ${TARGET}"
+echo " - TOOLCHAIN = ${TOOLCHAIN}"
+
+cd ~/rust-project
+mkdir -p build-out
+
+if [ -f build-in/main.rs ]; then
+  cat build-in/main.rs > examples/ledc-simple.rs
+fi
+
+cargo ${TOOLCHAIN} build --example ledc-simple --release --target ${TARGET}
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/${TARGET}/release/examples/ledc-simple -o build-out/project.bin

--- a/esp32-rust/install-rust-toolchain.sh
+++ b/esp32-rust/install-rust-toolchain.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Default values
-TOOLCHAIN_VERSION="1.58.0.0"
+TOOLCHAIN_VERSION="1.59.0.0"
 if [ -z "${RUSTUP_HOME}" ]; then
     RUSTUP_HOME="${HOME}/.rustup"
 fi


### PR DESCRIPTION
Pre-cached build of ESP32 and ESP32-C3.
It's sufficient to export variable and run `compile.sh`:
`export WOKWI_MCU="esp32"`
`export WOKWI_MCU="esp32-c3"`

The update contains switch to Rust 1.59.0.0 for Xtensa and to Rust nightly toolchain in order to build RISC-V.