### PR TITLE
Update esp-idf folder name

### DIFF
--- a/esp32-rust/Dockerfile
+++ b/esp32-rust/Dockerfile
@@ -1,7 +1,7 @@
 FROM sergiogasquez/esp-rs-env:wokwi
 
 # Install esptool
-RUN IDF_PATH=/home/esp/.espressif/frameworks/esp-idf-v4.4 . "/home/esp/.espressif/frameworks/esp-idf-v4.4/export.sh" \
+RUN IDF_PATH=/home/esp/.espressif/frameworks/esp-idf . "/home/esp/.espressif/frameworks/esp-idf/export.sh" \
     && pip3 install esptool
 
 # Examples from esp-idf-hal

--- a/esp32-rust/compile.sh
+++ b/esp32-rust/compile.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 . "$HOME/.cargo/env"
-. "$HOME/.espressif/frameworks/esp-idf-v4.4/export.sh"
+. "$HOME/.espressif/frameworks/esp-idf/export.sh"
 . "$HOME/export-rust.sh"
 
 set -e


### PR DESCRIPTION
Yesterday we [updated the esp-idf folder name](https://github.com/SergioGasquez/esp-rs-container/commit/9bd3cd470e413c018643deca67b9485c3a7c714c) to be more generic.

The images are still hosted under my personal Dockerhub account and they are changing rapidly (sorry for that), we plan on moving them under the espressif's Dockerhub account in the upcoming weeks where they will be way more stable.