### PR TITLE
Update build containers

### DIFF
--- a/esp32-rust/Cargo.toml
+++ b/esp32-rust/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "rust-project"
+version = "0.1.0"
+authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
+edition = "2018"
+resolver = "2"
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"
+
+[features]
+pio = ["esp-idf-sys/pio"]
+
+[dependencies]
+esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+log = "0.4"
+anyhow = "1"
+toml-cfg = "0.1"
+url = "2"
+esp-idf-svc = "0.41"
+esp-idf-hal = "0.37"
+embedded-svc = "0.21"
+embedded-hal = "=1.0.0-alpha.8"
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+embedded-graphics = "0.7"
+display-interface = "0.4"
+display-interface-spi = "0.4"
+st7789 = "0.6"
+ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+ssd1306 = "0.7"
+epd-waveshare = "0.5.0"
+regex = "1"
+soup = "0.5.1"
+time = { version = "0.3.9", features = ["macros", "parsing"]}
+
+[build-dependencies]
+embuild = "0.29"
+anyhow = "1"

--- a/esp32-rust/compile.sh
+++ b/esp32-rust/compile.sh
@@ -1,47 +1,12 @@
 #!/bin/sh
 
-. "$HOME/.cargo/env"
-. "$HOME/.espressif/frameworks/esp-idf/export.sh"
-. "$HOME/export-rust.sh"
-
 set -e
-
-case ${WOKWI_MCU} in
-    "esp32")
-      TOOLCHAIN="+esp"
-      TARGET="xtensa-esp32-espidf"
-      ARCHITECTURE="xtensa"
-      ;;
-    "esp32-s2")
-      TOOLCHAIN="+esp"
-      TARGET="xtensa-esp32s2-espidf"
-      ARCHITECTURE="xtensa"
-      ;;
-    "esp32-s3")
-      TOOLCHAIN="+esp"
-      TARGET="xtensa-esp32s3-espidf"
-      ARCHITECTURE="xtensa"
-      ;;
-    "esp32-c3")
-      TOOLCHAIN=""
-      TARGET="riscv32imc-esp-espidf"
-      ARCHITECTURE="riscv"
-      ;;
-    *) # unknown
-      echo "Environment variable WOKWI_MCU not set."
-      echo "Available values esp32, esp32-s2, esp32-s3, esp32-c3"
-      exit 1
-      ;;
-esac
-
-echo "Configuration of ${WOKWI_MCU}"
-echo " - TARGET    = ${TARGET}"
-echo " - TOOLCHAIN = ${TOOLCHAIN}"
-
-cd ~/rust-project-${ARCHITECTURE}
+. /home/esp/export-esp.sh
+pip3 install esptool
+cd rust-project
 if [ -f ${HOME}/build-in/main.rs ]; then
-  cat ${HOME}/build-in/main.rs > examples/ledc-simple.rs
+    cat ${HOME}/build-in/main.rs > src/main.rs
 fi
-cargo ${TOOLCHAIN} build --example ledc-simple --release --target ${TARGET}
-python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/${TARGET}/release/examples/ledc-simple -o ${HOME}/build-out/project.bin
-cp target/${TARGET}/release/examples/ledc-simple ${HOME}/build-out/project.elf
+cargo build --offline --release
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/xtensa-esp32-espidf/release/rust-project -o ${HOME}/build-out/project.bin
+cp target/xtensa-esp32-espidf/release/rust-project ${HOME}/build-out/project.elf

--- a/esp32-rust/fetch.sh
+++ b/esp32-rust/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+. /home/esp/export-esp.sh
+
+cd rust-project
+cargo fetch
+cargo build --release

--- a/esp32c3-rust/Cargo.toml
+++ b/esp32c3-rust/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "rust-project"
+version = "0.1.0"
+authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
+edition = "2018"
+resolver = "2"
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"
+
+[features]
+pio = ["esp-idf-sys/pio"]
+
+[dependencies]
+esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+log = "0.4"
+anyhow = "1"
+toml-cfg = "0.1"
+url = "2"
+esp-idf-svc = "0.41"
+esp-idf-hal = "0.37"
+embedded-svc = "0.21"
+embedded-hal = "=1.0.0-alpha.8"
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+embedded-graphics = "0.7"
+display-interface = "0.4"
+display-interface-spi = "0.4"
+st7789 = "0.6"
+ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+ssd1306 = "0.7"
+epd-waveshare = "0.5.0"
+regex = "1"
+soup = "0.5.1"
+time = { version = "0.3.9", features = ["macros", "parsing"]}
+riscv-rt = { version = "0.8", optional = true }
+
+
+
+[build-dependencies]
+embuild = "0.29"
+anyhow = "1"

--- a/esp32c3-rust/Dockerfile
+++ b/esp32c3-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32_v4.4_1.61.0.0
+FROM espressif/idf-rust:esp32c3_v4.4_1.61.0.0
 
 # Install cargo-generate
 USER esp
@@ -9,7 +9,7 @@ RUN curl -L https://github.com/cargo-generate/cargo-generate/releases/download/v
     -C /home/esp/.cargo/bin/ \
     && rm /home/esp/.cargo/bin/cargo-generate.tar.gz
 RUN chmod u+x /home/esp/.cargo/bin/cargo-generate
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32 --define toolchain=esp --define espidfver=v4.4 --define std=true \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32c3 --define toolchain=nightly --define espidfver=v4.4 --define std=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 

--- a/esp32c3-rust/compile.sh
+++ b/esp32c3-rust/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+. /home/esp/export-esp.sh
+pip3 install esptool
+cd rust-project
+if [ -f ${HOME}/build-in/main.rs ]; then
+    cat ${HOME}/build-in/main.rs > src/main.rs
+fi
+cargo build --offline --release
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/riscv32imc-esp-espidf/release/rust-project -o ${HOME}/build-out/project.bin
+cp target/riscv32imc-esp-espidf/release/rust-project ${HOME}/build-out/project.elf

--- a/esp32c3-rust/fetch.sh
+++ b/esp32c3-rust/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+. /home/esp/export-esp.sh
+
+cd rust-project
+cargo fetch
+cargo build --release

--- a/esp32c3-training/Cargo.toml
+++ b/esp32c3-training/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "hardware-check"
+version = "0.1.0"
+authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
+edition = "2021"
+resolver = "2"
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"
+
+[features]
+default = ["native"]
+native = ["esp-idf-sys/native"]
+
+[dependencies]
+esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
+esp32-c3-dkc02-bsc = { path = "../../common/lib/esp32-c3-dkc02-bsc" }
+log = "0.4"
+anyhow = "1"
+toml-cfg = "0.1"
+esp-idf-svc = { version="=0.39.1", features = ["experimental", "alloc"] }
+embedded-svc = "=0.19"
+esp32c3 = "=0.4.0"
+riscv = { version = "0.7", features=["inline-asm"] }
+get-uuid = { path = "../../common/lib/get-uuid" }
+mqtt-messages = { path = "../../common/lib/mqtt-messages" }
+esp-idf-hal = "0.35.1"
+embedded-hal = "0.2.7"
+shtcx = "0.10.0"
+lis3dh = "0.4.1"
+shared-bus = "0.2.2"
+imc42670p = { path = "../../common/lib/imc42670p" }
+
+[build-dependencies]
+embuild = "0.29.1"
+anyhow = "1"
+
+[patch.crates-io]
+riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b"}

--- a/esp32c3-training/Dockerfile
+++ b/esp32c3-training/Dockerfile
@@ -1,0 +1,60 @@
+FROM debian:bullseye-slim
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ARG CONTAINER_USER=esp
+ARG CONTAINER_GROUP=esp
+ARG NIGHTLY_VERSION=nightly-2022-03-10
+ARG ESP_IDF_VERSION=release/v4.4
+ARG ESP_BOARD=esp32c3
+
+RUN apt-get update \
+    && apt-get install -y git curl ninja-build clang libudev-dev \
+    python3 python3-pip libusb-1.0-0 libssl-dev pkg-config libtinfo5 \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
+
+RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
+USER ${CONTAINER_USER}
+WORKDIR /home/${CONTAINER_USER}
+ENV USER=${CONTAINER_USER}
+
+ENV PATH=${PATH}:$HOME/.cargo/bin
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
+    --default-toolchain ${NIGHTLY_VERSION} -y --profile minimal \
+    && $HOME/.cargo/bin/rustup component add rust-src --toolchain ${NIGHTLY_VERSION} \
+    && $HOME/.cargo/bin/rustup target add riscv32i-unknown-none-elf
+
+RUN $HOME/.cargo/bin/cargo install cargo-espflash espmonitor ldproxy
+RUN mkdir -p ${HOME}/.espressif/frameworks/ \
+    && git clone --branch ${ESP_IDF_VERSION} -q --depth 1 --shallow-submodules \
+    --recursive https://github.com/espressif/esp-idf.git \
+    ${HOME}/.espressif/frameworks/esp-idf \
+    && python3 ${HOME}/.espressif/frameworks/esp-idf/tools/idf_tools.py install cmake \
+    && ${HOME}/.espressif/frameworks/esp-idf/install.sh ${ESP_BOARD} \
+    && rm -rf .espressif/dist \
+    && rm -rf .espressif/frameworks/esp-idf/docs \
+    && rm -rf .espressif/frameworks/esp-idf/examples \
+    && rm -rf .espressif/frameworks/esp-idf/tools/esp_app_trace \
+    && rm -rf .espressif/frameworks/esp-idf/tools/test_idf_size
+
+RUN git clone -b feature/devcontainer https://github.com/SergioGasquez/espressif-trainings.git espressif-trainings \
+    && rm -rf espressif-trainings/book \
+    && rm espressif-trainings/intro/hardware-check/Cargo.toml
+COPY Cargo.toml espressif-trainings/intro/hardware-check/Cargo.toml
+
+# Fetch
+COPY fetch.sh /home/esp/
+RUN bash fetch.sh
+
+# Copy compilation script
+COPY compile.sh /home/esp/
+RUN mkdir -p /home/esp/build-in /home/esp/build-out
+
+RUN echo "[hardware-check]" > espressif-trainings/intro/hardware-check/cfg.toml \
+    && echo "wifi_ssid = \"Wokwi-GUEST\"" >> espressif-trainings/intro/hardware-check/cfg.toml \
+    && echo "wifi_psk = \"\"" >> espressif-trainings/intro/hardware-check/cfg.toml \
+    && echo "mqtt_user = \"\"" >> espressif-trainings/intro/hardware-check/cfg.toml \
+    && echo "mqtt_pass = \"\"" >> espressif-trainings/intro/hardware-check/cfg.toml \
+    && echo "mqtt_host = \"broker.mqttdashboard.com\"" >> espressif-trainings/intro/hardware-check/cfg.toml

--- a/esp32c3-training/compile.sh
+++ b/esp32c3-training/compile.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+. "$HOME/.cargo/env"
+export IDF_TOOLS_PATH=/home/esp/.espressif
+. /home/esp/.espressif/frameworks/esp-idf/export.sh
+pip3 install esptool
+cd espressif-trainings/intro/hardware-check
+if [ -f ${HOME}/build-in/main.rs ]; then
+    cat ${HOME}/build-in/main.rs > src/main.rs
+fi
+
+if [ -f ${HOME}/build-in/lib.rs ]; then
+    cat ${HOME}/build-in/lib.rs > src/lib.rs
+fi
+
+if [ -f ${HOME}/build-in/imc42670p.rs ]; then
+    cat ${HOME}/build-in/imc42670p.rs > src/imc42670p.rs
+fi
+cargo build --offline --release
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/riscv32imc-esp-espidf/release/hardware-check -o ${HOME}/build-out/project.bin
+cp target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.elf

--- a/esp32c3-training/fetch.sh
+++ b/esp32c3-training/fetch.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -e
+export IDF_TOOLS_PATH=/home/esp/.espressif
+. "$HOME/.cargo/env"
+. /home/esp/.espressif/frameworks/esp-idf/export.sh
+
+cd espressif-trainings/intro/hardware-check
+cargo fetch
+cargo build --release

--- a/esp32s2-rust/Cargo.toml
+++ b/esp32s2-rust/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "rust-project"
+version = "0.1.0"
+authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
+edition = "2018"
+resolver = "2"
+
+[profile.release]
+opt-level = "s"
+
+[profile.dev]
+debug = true # Symbols are nice and they don't increase the size on Flash
+opt-level = "z"
+
+[features]
+pio = ["esp-idf-sys/pio"]
+
+[dependencies]
+esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+log = "0.4"
+anyhow = "1"
+toml-cfg = "0.1"
+url = "2"
+esp-idf-svc = "0.41"
+esp-idf-hal = "0.37"
+embedded-svc = "0.21"
+embedded-hal = "=1.0.0-alpha.8"
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+embedded-graphics = "0.7"
+display-interface = "0.4"
+display-interface-spi = "0.4"
+st7789 = "0.6"
+ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+ssd1306 = "0.7"
+epd-waveshare = "0.5.0"
+regex = "1"
+soup = "0.5.1"
+time = { version = "0.3.9", features = ["macros", "parsing"]}
+
+
+[build-dependencies]
+embuild = "0.29"
+anyhow = "1"

--- a/esp32s2-rust/Dockerfile
+++ b/esp32s2-rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32_v4.4_1.61.0.0
+FROM espressif/idf-rust:esp32s2_v4.4_1.61.0.0
 
 # Install cargo-generate
 USER esp
@@ -9,7 +9,7 @@ RUN curl -L https://github.com/cargo-generate/cargo-generate/releases/download/v
     -C /home/esp/.cargo/bin/ \
     && rm /home/esp/.cargo/bin/cargo-generate.tar.gz
 RUN chmod u+x /home/esp/.cargo/bin/cargo-generate
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32 --define toolchain=esp --define espidfver=v4.4 --define std=true \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32s2 --define toolchain=esp --define espidfver=v4.4 --define std=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 

--- a/esp32s2-rust/compile.sh
+++ b/esp32s2-rust/compile.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+. /home/esp/export-esp.sh
+pip3 install esptool
+cd rust-project
+if [ -f ${HOME}/build-in/main.rs ]; then
+    cat ${HOME}/build-in/main.rs > src/main.rs
+fi
+cargo build --offline --release
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/xtensa-esp32s2-espidf/release/rust-project -o ${HOME}/build-out/project.bin
+cp target/xtensa-esp32s2-espidf/release/rust-project ${HOME}/build-out/project.elf

--- a/esp32s2-rust/fetch.sh
+++ b/esp32s2-rust/fetch.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -e
+. /home/esp/export-esp.sh
+
+cd rust-project
+cargo fetch
+cargo build --release


### PR DESCRIPTION
- Since we no longer have images for all boards, I have split the builders per target. 
- Added a fetch script that fetches dependencies and build the project
- Compile scripts now uses `--offline` argument
- Use [esp-rs/esp-idf-template](https://github.com/esp-rs/esp-idf-template) as base project with a custom `Cargo.toml` which includes common dependencies.
- Added esp32c3-training builder for Ferrous System training.