### PR TITLE
Updated Cargo.toml

### DIFF
--- a/rust-nostd-esp32/Cargo.toml
+++ b/rust-nostd-esp32/Cargo.toml
@@ -13,20 +13,26 @@ debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
+xtensa-atomic-emulation-trap = "0.2.0"
 esp32-hal = { package = "esp32-hal", git = "https://github.com/esp-rs/esp-hal.git", rev = "e9f22ac" }
 xtensa-lx-rt = { version = "0.13.0", features = ["esp32"], optional = true }
+esp-println = { version = "0.3.0", features = ["esp32"] }
 esp-backtrace = { version = "0.1.0", features = [
     "esp32",
     "panic-handler",
     "print-uart",
 ] }
+
 ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
-esp-println = { version = "0.3.0", features = ["esp32"] }
-embedded-graphics = "0.7.1"
+display-interface = "0.4"
 display-interface-spi = "0.4.1"
+embedded-graphics = "0.7.1"
 embedded-graphics-core = "0.3.3"
-profont = "0.6.1"
+embedded-hal = "0.2.7"
+profont = "0.6.1"   # font with extended signs and options of sizing (unlike fonts in embedded-graphics)
+tinybmp = "0.3.3"
 
 [features]
-default = ["rt"]
+default = [ "rt", "eh1" ]
 rt = ["xtensa-lx-rt"]
+eh1 = ["esp32-hal/eh1"] # required for blocking traits 

--- a/rust-nostd-esp32c3/Cargo.toml
+++ b/rust-nostd-esp32c3/Cargo.toml
@@ -14,19 +14,24 @@ opt-level = "z"
 
 [dependencies]
 esp32c3-hal = { package = "esp32c3-hal", git = "https://github.com/esp-rs/esp-hal.git", rev = "e9f22ac" }
+riscv-rt = { version = "0.9", optional = true }
+esp-println = { version = "0.3.0", features = ["esp32c3"] }
 esp-backtrace = { version = "0.1.0", features = [
     "esp32c3",
     "panic-handler",
     "print-uart",
 ] }
-riscv-rt = { version = "0.9", optional = true }
+
 ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
-esp-println = { version = "0.3.0", features = ["esp32c3"] }
-embedded-graphics = "0.7.1"
+display-interface = "0.4"
 display-interface-spi = "0.4.1"
+embedded-graphics = "0.7.1"
 embedded-graphics-core = "0.3.3"
-profont = "0.6.1"
+embedded-hal = "0.2.7"
+profont = "0.6.1"   # font with extended signs and options of sizing (unlike fonts in embedded-graphics)
+tinybmp = "0.3.3"
 
 [features]
-default = ["rt"]
+default = [ "rt", "eh1" ]
 rt = ["riscv-rt"]
+eh1 = ["esp32c3-hal/eh1"] #required for blocking traits

--- a/rust-nostd-esp32s2/Cargo.toml
+++ b/rust-nostd-esp32s2/Cargo.toml
@@ -13,22 +13,26 @@ debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [dependencies]
+xtensa-atomic-emulation-trap = "0.2.0"
 esp32s2-hal = { package = "esp32s2-hal", git = "https://github.com/esp-rs/esp-hal.git", rev = "e9f22ac" }
 xtensa-lx-rt = { version = "0.13.0", features = ["esp32s2"], optional = true }
+esp-println = { version = "0.3.0", features = ["esp32s2"] }
 esp-backtrace = { version = "0.1.0", features = [
     "esp32s2",
     "panic-handler",
     "print-uart",
 ] }
-ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
-esp-println = { version = "0.3.0", features = ["esp32s2"] }
-embedded-graphics = "0.7.1"
-display-interface-spi = "0.4.1"
-embedded-graphics-core = "0.3.3"
-profont = "0.6.1"
-xtensa-atomic-emulation-trap = "0.2.0"
 
+ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+display-interface = "0.4"
+display-interface-spi = "0.4.1"
+embedded-graphics = "0.7.1"
+embedded-graphics-core = "0.3.3"
+embedded-hal = "0.2.7"
+profont = "0.6.1"   # font with extended signs and options of sizing (unlike fonts in embedded-graphics)
+tinybmp = "0.3.3"
 
 [features]
-default = ["rt"]
+default = [ "rt", "eh1" ]
 rt = ["xtensa-lx-rt"]
+eh1 = ["esp32s2-hal/eh1"] # required for blocking traits 


### PR DESCRIPTION
Added new dependencies to cover as more as possible user needs, added `eh1` feature(not builds without it), added `xtensa-atomic-emulation-trap` dependency for `esp32` and `esp32s2` chips