### PR TITLE
Enable alloc

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -7,10 +7,10 @@ ENV USER=esp
 RUN cargo install sccache
 
 # Generate project templates
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32 --vcs none --silent -d mcu=esp32 -d devcontainer=false -d alloc=false
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s2 --vcs none --silent -d mcu=esp32s2 -d devcontainer=false -d alloc=false
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s3 --vcs none --silent -d mcu=esp32s3 -d devcontainer=false -d alloc=false
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false -d alloc=false
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32 --vcs none --silent -d mcu=esp32 -d devcontainer=false -d alloc=true
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s2 --vcs none --silent -d mcu=esp32s2 -d devcontainer=false -d alloc=true
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s3 --vcs none --silent -d mcu=esp32s3 -d devcontainer=false -d alloc=true
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false -d alloc=true
 
 # Copy utility scripts and setup
 COPY compile.sh fetch.sh /home/esp/


### PR DESCRIPTION
When using `alloc` option of the template, the `.cargo/config.toml` will include [the necessary options to allocate](https://github.com/esp-rs/esp-template/blob/6c00b41b25732208f82f9bc0cbbec84f24b249bd/.cargo/config.toml#L45).

At the moment you can include the [`esp-alloc` crate](https://crates.io/crates/esp-alloc) on the `Cargo.toml`, but as users cannot edit the `.cargo/config.toml` they will not be able to use it.