### PR TITLE
Update builders and add audit

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -3,7 +3,7 @@ FROM espressif/idf-rust:all_latest
 USER esp
 ENV USER=esp
 
-# Install sccacahe
+# Install cargo-audit
 RUN cargo install cargo-audit
 
 # Generate project templates

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_latest
+FROM espressif/idf-rust:all_1.66.0.0
 
 USER esp
 ENV USER=esp

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -4,7 +4,7 @@ USER esp
 ENV USER=esp
 
 # Install sccacahe
-RUN cargo install sccache
+RUN cargo install sccache cargo-audit
 
 # Generate project templates
 RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32 --vcs none --silent -d mcu=esp32 -d devcontainer=false -d alloc=true

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,16 +1,16 @@
-FROM espressif/idf-rust:all_1.64.0.0
+FROM espressif/idf-rust:all_latest
 
 USER esp
 ENV USER=esp
 
 # Install sccacahe
-RUN cargo install sccache cargo-audit
+RUN cargo install cargo-audit
 
 # Generate project templates
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32 --vcs none --silent -d mcu=esp32 -d devcontainer=false -d alloc=true
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s2 --vcs none --silent -d mcu=esp32s2 -d devcontainer=false -d alloc=true
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32s3 --vcs none --silent -d mcu=esp32s3 -d devcontainer=false -d alloc=true
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-template --name rust-project-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false -d alloc=true
+RUN cargo generate --git https://github.com/esp-rs/esp-template --name rust-project-esp32 --vcs none --silent -d mcu=esp32 -d devcontainer=false -d alloc=true
+RUN cargo generate --git https://github.com/esp-rs/esp-template --name rust-project-esp32s2 --vcs none --silent -d mcu=esp32s2 -d devcontainer=false -d alloc=true
+RUN cargo generate --git https://github.com/esp-rs/esp-template --name rust-project-esp32s3 --vcs none --silent -d mcu=esp32s3 -d devcontainer=false -d alloc=true
+RUN cargo generate --git https://github.com/esp-rs/esp-template --name rust-project-esp32c3 --vcs none --silent -d mcu=esp32c3 -d devcontainer=false -d alloc=true
 
 # Copy utility scripts and setup
 COPY compile.sh fetch.sh /home/esp/

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -6,22 +6,22 @@ export CARGO_INCREMENTAL=0
 export RUSTC_WRAPPER=$(which sccache)
 
 case ${WOKWI_MCU} in
-    "esp32")
-        PROJECT_NAME="rust-project-esp32"
-        ;;
-    "esp32-c3")
-        PROJECT_NAME="rust-project-esp32c3"
-        ;;
-    "esp32-s2")
-        PROJECT_NAME="rust-project-esp32s2"
-        ;;
-    "esp32-s3")
-        PROJECT_NAME="rust-project-esp32s3"
-        ;;
-    *)
-        echo "Missing or invalid WOKWI_MCU environment variable"
-        exit 1
-        ;;
+"esp32")
+    PROJECT_NAME="rust-project-esp32"
+    ;;
+"esp32-c3")
+    PROJECT_NAME="rust-project-esp32c3"
+    ;;
+"esp32-s2")
+    PROJECT_NAME="rust-project-esp32s2"
+    ;;
+"esp32-s3")
+    PROJECT_NAME="rust-project-esp32s3"
+    ;;
+*)
+    echo "Missing or invalid WOKWI_MCU environment variable"
+    exit 1
+    ;;
 esac
 
 cd ${PROJECT_NAME}
@@ -37,6 +37,7 @@ fi
 
 PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
 PROJECT_NAME_UNDERSCORE=${PROJECT_NAME//-/_}
+cargo audit
 cargo build --release --out-dir output -Z unstable-options
 python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME_UNDERSCORE} -o ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME_UNDERSCORE} ${HOME}/build-out/project.elf

--- a/rust-std-esp32/Cargo.toml
+++ b/rust-std-esp32/Cargo.toml
@@ -9,34 +9,36 @@ resolver = "2"
 opt-level = "s"
 
 [profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
+debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
 pio = ["esp-idf-sys/pio"]
 
 [dependencies]
-esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
 log = "0.4"
 anyhow = "1"
 toml-cfg = "0.1"
 url = "2"
-esp-idf-svc = "0.42"
-esp-idf-hal = "0.37"
-embedded-svc = "0.21"
-embedded-hal = "=1.0.0-alpha.8"
-embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+esp-idf-svc = "0.45.0"
+esp-idf-hal = "0.40.1"
+embedded-svc = "0.24.0"
+embedded-hal = "=1.0.0-alpha.9"
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = [
+    "unproven",
+] }
 embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
-st7789 = "0.6"
+st7789 = "0.7.0"
 ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 regex = "1"
 soup = "0.5.1"
-time = { version = "0.3.9", features = ["macros", "parsing"]}
+time = { version = "0.3.9", features = ["macros", "parsing"] }
 
 [build-dependencies]
-embuild = "0.29"
+embuild = "0.31.0"
 anyhow = "1"

--- a/rust-std-esp32/Dockerfile
+++ b/rust-std-esp32/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32_v4.4_latest
+FROM espressif/idf-rust:esp32_v4.4_1.66.0.0
 
 # Install cargo-generate
 USER esp

--- a/rust-std-esp32/Dockerfile
+++ b/rust-std-esp32/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32_v4.4_1.64.0.0
+FROM espressif/idf-rust:esp32_v4.4_latest
 
 # Install cargo-generate
 USER esp

--- a/rust-std-esp32c3/Cargo.toml
+++ b/rust-std-esp32c3/Cargo.toml
@@ -16,29 +16,29 @@ opt-level = "z"
 pio = ["esp-idf-sys/pio"]
 
 [dependencies]
-esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
 log = "0.4"
 anyhow = { version = "1", features = ["backtrace"] }
 toml-cfg = "0.1"
 url = "2"
-esp-idf-svc = "0.42"
-esp-idf-hal = "0.37"
-embedded-svc = "0.22"
-embedded-hal = "=1.0.0-alpha.8"
+esp-idf-svc = "0.45.0"
+esp-idf-hal = "0.40.1"
+embedded-svc = "0.24.0"
+embedded-hal = "=1.0.0-alpha.9"
 embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = [
     "unproven",
 ] }
 embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
-st7789 = "0.6"
+st7789 = "0.7"
 ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 regex = "1"
 soup = "0.5.1"
 time = { version = "0.3.9", features = ["macros", "std", "parsing"] }
-riscv-rt = { version = "0.8", optional = true }
+riscv-rt = { version = "0.10", optional = true }
 # esp-clock
 embedded-text = "0.5.0"
 rustzx-utils = { version = "0.15", features = ["std"] }
@@ -47,10 +47,10 @@ icm42670 = { git = "https://github.com/jessebraham/icm42670" }
 shared-bus = "0.2.4"
 shtcx = "0.10.0"
 bitmap-font = "0.2.2"
-tinybmp = "0.3.3"
+tinybmp = "0.4.0"
 profont = "0.6.1"
 cfg-if = "1.0.0"
 
 [build-dependencies]
-embuild = "0.29"
+embuild = "0.31"
 anyhow = "1"

--- a/rust-std-esp32c3/Dockerfile
+++ b/rust-std-esp32c3/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32c3_v4.4_latest
+FROM espressif/idf-rust:esp32c3_v4.4_1.66.0.0
 
 # Install cargo-generate
 USER esp

--- a/rust-std-esp32c3/Dockerfile
+++ b/rust-std-esp32c3/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32c3_v4.4_1.63.0.2
+FROM espressif/idf-rust:esp32c3_v4.4_latest
 
 # Install cargo-generate
 USER esp

--- a/rust-std-esp32s2/Cargo.toml
+++ b/rust-std-esp32s2/Cargo.toml
@@ -9,34 +9,36 @@ resolver = "2"
 opt-level = "s"
 
 [profile.dev]
-debug = true # Symbols are nice and they don't increase the size on Flash
+debug = true    # Symbols are nice and they don't increase the size on Flash
 opt-level = "z"
 
 [features]
 pio = ["esp-idf-sys/pio"]
 
 [dependencies]
-esp-idf-sys = { version = "0.31.5", features = ["binstart"] }
+esp-idf-sys = { version = "0.32.1", features = ["binstart"] }
 log = "0.4"
 anyhow = "1"
 toml-cfg = "0.1"
 url = "2"
-esp-idf-svc = "0.42"
-esp-idf-hal = "0.37"
-embedded-svc = "0.21"
-embedded-hal = "=1.0.0-alpha.8"
-embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = ["unproven"] }
+esp-idf-svc = "0.45.0"
+esp-idf-hal = "0.40.1"
+embedded-svc = "0.24.0"
+embedded-hal = "=1.0.0-alpha.9"
+embedded-hal-0-2 = { package = "embedded-hal", version = "0.2.7", features = [
+    "unproven",
+] }
 embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
-st7789 = "0.6"
+st7789 = "0.7"
 ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 regex = "1"
 soup = "0.5.1"
-time = { version = "0.3.9", features = ["macros", "parsing"]}
+time = { version = "0.3.9", features = ["macros", "parsing"] }
 
 [build-dependencies]
-embuild = "0.29"
+embuild = "0.31"
 anyhow = "1"

--- a/rust-std-esp32s2/Dockerfile
+++ b/rust-std-esp32s2/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32s2_v4.4_1.63.0.2
+FROM espressif/idf-rust:esp32s2_v4.4_latest
 
 # Install cargo-generate
 USER esp

--- a/rust-std-esp32s2/Dockerfile
+++ b/rust-std-esp32s2/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:esp32s2_v4.4_latest
+FROM espressif/idf-rust:esp32s2_v4.4_1.66.0.0
 
 # Install cargo-generate
 USER esp


### PR DESCRIPTION
- Update builders to use `latest` tag instead of hardcoded version
- Add cargo audit check to `rust-nostd-esp` builder
- Update dependencies for std builders