### PR TITLE
Fix rust-std-esp32c3 builder

### DIFF
--- a/rust-std-esp32c3/Cargo.toml
+++ b/rust-std-esp32c3/Cargo.toml
@@ -32,20 +32,20 @@ embedded-graphics = "0.7"
 display-interface = "0.4"
 display-interface-spi = "0.4"
 st7789 = "0.7"
-ili9341 = { version = "0.5", git = "https://github.com/yuri91/ili9341-rs" }
+ili9341 = { version = "0.5" }
 ssd1306 = "0.7"
 epd-waveshare = "0.5.0"
 regex = "1"
 soup = "0.5.1"
 time = { version = "0.3.9", features = ["macros", "std", "parsing"] }
-riscv-rt = { version = "0.10", optional = true }
+riscv-rt = { version = "0.11", optional = true }
 # esp-clock
 embedded-text = "0.5.0"
 rustzx-utils = { version = "0.15", features = ["std"] }
 rustzx-core = { version = "0.15", features = ["embedded-roms"] }
 icm42670 = { git = "https://github.com/jessebraham/icm42670" }
 shared-bus = "0.2.4"
-shtcx = "0.10.0"
+shtcx = "0.11.0"
 bitmap-font = "0.2.2"
 tinybmp = "0.4.0"
 profont = "0.6.1"


### PR DESCRIPTION
- Updated `riscv-rt `crate as v0.10 was yanked 
- Other minor updates

CI test: https://github.com/SergioGasquez/wokwi-builders/actions/runs/4302220698

`rust-training-esp32c3` is also failing, but I would suggest addressing this builder once we have the training in a better spot (we are currently working on this as the repo just got transferred to our organization)