### PR TITLE
Make Zephyr build container much faster

### DIFF
--- a/zephyr-esp32/Dockerfile
+++ b/zephyr-esp32/Dockerfile
@@ -1,36 +1,17 @@
-FROM ubuntu:20.04
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
+FROM ghcr.io/beriberikix/zephyr-xtensa-espressif_esp32:v3.3.0-0.16.0sdk
 
 RUN apt update \
-  && apt install -y --no-install-recommends git ninja-build gperf \
-  ccache dfu-util device-tree-compiler wget \
-  python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
-  make gcc gcc-multilib g++-multilib libsdl2-dev gnupg software-properties-common \
-  && pip3 install wheel west
-
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add - \
-  && apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' \
-  && apt-get update \
-  && apt-get install -y cmake
+  && apt install -y --no-install-recommends python3-pip \
+  && pip3 install pyserial
 
 RUN adduser --disabled-password --gecos "" wokwi
 USER wokwi
 WORKDIR /home/wokwi
 
-RUN west init -m https://github.com/zephyrproject-rtos/zephyr --mr zephyr-v3.0.0 ~/zephyrproject
+RUN west init --mr zephyr-v3.3.0 ~/zephyrproject
 WORKDIR /home/wokwi/zephyrproject/
-RUN west update --narrow && west espressif update
-RUN pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
-RUN west espressif install
-
-ENV ZEPHYR_TOOLCHAIN_VARIANT=espressif
-ENV HOME=/home/wokwi
-ENV ESPRESSIF_TOOLCHAIN_PATH="$HOME/.espressif/tools/zephyr"
-ENV PATH="$PATH:$ESPRESSIF_TOOLCHAIN_PATH/bin"
-ENV IDF_PATH="$HOME/zephyrproject/modules/hal/espressif"
+RUN west update --narrow
+RUN west blobs fetch hal_espressif
 
 WORKDIR /home/wokwi/zephyrproject/zephyr
 COPY esp32-wokwi.dts samples/basic/blinky/app.overlay


### PR DESCRIPTION
The previous container was building the entire container from scratch. Instead, the new builder is using a pre-built, optimized container from https://github.com/beriberikix/zephyr-docker.