### PR TITLE
Update rust-training-esp32c3 image

### DIFF
--- a/rust-training-esp32c3/Cargo.toml
+++ b/rust-training-esp32c3/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hardware-check"
 version = "0.1.0"
-authors = ["Anatol Ulrich <anatol.ulrich@ferrous-systems.com>"]
+authors = ["Sergio Gasquez <sergio.gasquez@gmail.com>"]
 edition = "2021"
 resolver = "2"
 
@@ -9,7 +9,7 @@ resolver = "2"
 opt-level = "s"
 
 [profile.dev]
-debug = true    # Symbols are nice and they don't increase the size on Flash
+debug = true
 opt-level = "z"
 
 [features]
@@ -17,27 +17,25 @@ default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-esp-idf-sys = { version = "=0.31.5", features = ["binstart"] }
-esp32-c3-dkc02-bsc = { path = "../../common/lib/esp32-c3-dkc02-bsc" }
-log = "0.4"
-anyhow = "1"
-toml-cfg = "0.1"
-esp-idf-svc = { version = "=0.42.1", features = ["experimental", "alloc"] }
-embedded-svc = "=0.22.1"
-esp32c3 = "=0.5.0"
-riscv = { version = "0.7", features = ["inline-asm"] }
+anyhow = "=1.0.69"
+embedded-hal = "=0.2.7"
+embedded-svc = "=0.24.0"
+esp-idf-hal = "=0.40.1"
+esp-idf-svc = { version = "=0.45.0", features = ["experimental", "alloc"] }
+esp-idf-sys = { version = "=0.32.1", features = ["binstart"] }
 get-uuid = { path = "../../common/lib/get-uuid" }
+icm42670 = "=0.1.1"
+lis3dh = "=0.4.2"
+log = "=0.4.17"
 mqtt-messages = { path = "../../common/lib/mqtt-messages" }
-esp-idf-hal = "0.38.1"
-embedded-hal = "0.2.7"
-shtcx = "0.10.0"
-lis3dh = "0.4.1"
-shared-bus = "0.2.2"
-icm42670p = { path = "../../common/lib/icm42670p" }
+rgb-led = { path = "../../common/lib/rgb-led" }
+shared-bus = "=0.2.5"
+shtcx = "=0.11.0"
+toml-cfg = "=0.1.3"
+wifi = { path = "../../common/lib/wifi" }
+
 
 [build-dependencies]
-embuild = "0.30.3"
-anyhow = "1"
-
-[patch.crates-io]
-riscv = { git = "https://github.com/rust-embedded/riscv", rev = "396fb9b" }
+anyhow = "=1.0.69"
+embuild = "=0.31.0"
+toml-cfg = "=0.1.3"

--- a/rust-training-esp32c3/Dockerfile
+++ b/rust-training-esp32c3/Dockerfile
@@ -1,54 +1,22 @@
 # Base image
-ARG VARIANT=bullseye-slim
-FROM debian:${VARIANT}
-ENV DEBIAN_FRONTEND=noninteractive
-ENV LC_ALL=C.UTF-8
-ENV LANG=C.UTF-8
-# Arguments
-ARG CONTAINER_USER=esp
-ARG CONTAINER_GROUP=esp
-ARG NIGHTLY_TOOLCHAIN_VERSION=nightly-2022-03-10
-ARG XTENSA_TOOLCHAIN_VERSION=1.63.0.2
-ARG ESP_BOARD=esp32c3
-ARG INSTALL_RUST_TOOLCHAIN=install-rust-toolchain.sh
-# The following variable must also be present during container run time:
-ENV ESP_IDF_VERSION=v4.4.1
-# Install dependencies
-RUN apt-get update \
-    && apt-get install -y git curl gcc clang ninja-build libudev-dev unzip xz-utils \
-    python3 python3-pip python3-venv libusb-1.0-0 libssl-dev pkg-config libtinfo5  libpython2.7 \
-    && apt-get clean -y && rm -rf /var/lib/apt/lists/* /tmp/library-scripts
-# Set user
-RUN adduser --disabled-password --gecos "" ${CONTAINER_USER}
-USER ${CONTAINER_USER}
-WORKDIR /home/${CONTAINER_USER}
-# Install rust toolchain(s), extra crates and esp-idf.
-ENV PATH=${PATH}:/home/${CONTAINER_USER}/.cargo/bin
-ADD --chown=${CONTAINER_USER}:${CONTAINER_GROUP} \
-    https://github.com/esp-rs/rust-build/releases/download/v${XTENSA_TOOLCHAIN_VERSION}/${INSTALL_RUST_TOOLCHAIN} \
-    ${INSTALL_RUST_TOOLCHAIN}
-RUN chmod a+x ${INSTALL_RUST_TOOLCHAIN} \
-    && ./${INSTALL_RUST_TOOLCHAIN} \
-    --extra-crates "ldproxy" \
-    --build-target "${ESP_BOARD}" \
-    --nightly-version "${NIGHTLY_TOOLCHAIN_VERSION}" \
-    --esp-idf-version "${ESP_IDF_VERSION}" \
-    --minified-esp-idf "YES" \
-    --export-file  ${HOME}/export-esp.sh
-
-# Activate ESP-IDF and Xtensa Rust toolchain environment
-RUN echo "source ${HOME}/export-esp.sh" >> ~/.bashrc
-
+FROM espressif/rust-std-training
+WORKDIR /root
 RUN git clone https://github.com/ferrous-systems/espressif-trainings.git espressif-trainings \
     && rm -rf espressif-trainings/book \
     && rm espressif-trainings/intro/hardware-check/Cargo.toml
 
+ENV IDF_TOOLS_PATH=/root/.espressif
+RUN echo "source /root/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+ENV PATH=${PATH}:/root/.cargo/bin
+
 COPY Cargo.toml espressif-trainings/intro/hardware-check/Cargo.toml
 COPY sdkconfig.defaults espressif-trainings/intro/hardware-check/sdkconfig.defaults
+COPY cfg.toml espressif-trainings/intro/hardware-check/cfg.toml
+
 # Fetch
-COPY fetch.sh /home/esp/
+COPY fetch.sh /root/
 RUN bash fetch.sh
 
 # Copy compilation script
-COPY compile.sh /home/esp/
-RUN mkdir -p /home/esp/build-in /home/esp/build-out
+COPY compile.sh /root/
+RUN mkdir -p /root/build-in /root/build-out

--- a/rust-training-esp32c3/Dockerfile
+++ b/rust-training-esp32c3/Dockerfile
@@ -20,3 +20,8 @@ RUN bash fetch.sh
 # Copy compilation script
 COPY compile.sh /root/
 RUN mkdir -p /root/build-in /root/build-out
+
+ENV HEXI_SRC_DIR="/home/esp/build-in"
+ENV HEXI_BUILD_CMD="bash /home/esp/compile.sh"
+ENV HEXI_OUT_HEX="/home/esp/build-out/project.bin"
+ENV HEXI_OUT_ELF="/home/esp/build-out/project.elf"

--- a/rust-training-esp32c3/Dockerfile
+++ b/rust-training-esp32c3/Dockerfile
@@ -1,25 +1,26 @@
 # Base image
 FROM espressif/rust-std-training
-WORKDIR /root
+USER esp
+ENV USER=esp
 RUN git clone https://github.com/ferrous-systems/espressif-trainings.git espressif-trainings \
     && rm -rf espressif-trainings/book \
     && rm espressif-trainings/intro/hardware-check/Cargo.toml
 
-ENV IDF_TOOLS_PATH=/root/.espressif
-RUN echo "source /root/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
-ENV PATH=${PATH}:/root/.cargo/bin
+ENV IDF_TOOLS_PATH=/home/esp/.espressif
+RUN echo "source /home/esp/.espressif/frameworks/esp-idf/export.sh > /dev/null 2>&1" >> ~/.bashrc
+ENV PATH=${PATH}:/home/esp/.cargo/bin
 
 COPY Cargo.toml espressif-trainings/intro/hardware-check/Cargo.toml
 COPY sdkconfig.defaults espressif-trainings/intro/hardware-check/sdkconfig.defaults
 COPY cfg.toml espressif-trainings/intro/hardware-check/cfg.toml
 
 # Fetch
-COPY fetch.sh /root/
+COPY fetch.sh /home/esp/
 RUN bash fetch.sh
 
 # Copy compilation script
-COPY compile.sh /root/
-RUN mkdir -p /root/build-in /root/build-out
+COPY compile.sh /home/esp/
+RUN mkdir -p /home/esp/build-in /home/esp/build-out
 
 ENV HEXI_SRC_DIR="/home/esp/build-in"
 ENV HEXI_BUILD_CMD="bash /home/esp/compile.sh"

--- a/rust-training-esp32c3/cfg.toml
+++ b/rust-training-esp32c3/cfg.toml
@@ -1,0 +1,6 @@
+[hardware-check]
+wifi_ssid = "Wokwi-GUEST"
+wifi_psk = ""
+mqtt_user = ""
+mqtt_pass = ""
+mqtt_host = "broker.mqttdashboard.com"

--- a/rust-training-esp32c3/compile.sh
+++ b/rust-training-esp32c3/compile.sh
@@ -1,19 +1,18 @@
 #!/bin/bash
 
 set -e
-. /home/esp/export-esp.sh
 
 cd espressif-trainings/intro/hardware-check
 if [ -f ${HOME}/build-in/main.rs ]; then
-    cat ${HOME}/build-in/main.rs > src/main.rs
+    cat ${HOME}/build-in/main.rs >src/main.rs
 fi
 
 if [ -f ${HOME}/build-in/lib.rs ]; then
-    cat ${HOME}/build-in/lib.rs > src/lib.rs
+    cat ${HOME}/build-in/lib.rs >src/lib.rs
 fi
 
 if [ -f ${HOME}/build-in/imc42670p.rs ]; then
-    cat ${HOME}/build-in/imc42670p.rs > src/imc42670p.rs
+    cat ${HOME}/build-in/imc42670p.rs >src/imc42670p.rs
 fi
 cargo build --offline --release
 python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/riscv32imc-esp-espidf/release/hardware-check -o ${HOME}/build-out/project.bin

--- a/rust-training-esp32c3/fetch.sh
+++ b/rust-training-esp32c3/fetch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 set -e
-. /home/esp/export-esp.sh
 pip3 install esptool
 
 cd espressif-trainings/intro/hardware-check

--- a/rust-training-esp32c3/sdkconfig.defaults
+++ b/rust-training-esp32c3/sdkconfig.defaults
@@ -1,10 +1,6 @@
 # Rust often needs a bit of an extra main task stack size compared to C (the default is 3K)
 CONFIG_ESP_MAIN_TASK_STACK_SIZE=7000
 
-# Use this to set FreeRTOS kernel tick frequency to 1000 Hz (100 Hz by default).
-# This allows to use 1 ms granuality for thread sleeps (10 ms by default).
-#CONFIG_FREERTOS_HZ=1000
-
-# Workaround for https://github.com/espressif/esp-idf/issues/7631
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
-#CONFIG_MBEDTLS_CERTIFICATE_BUNDLE_DEFAULT_FULL=n
+# TODO this does not seem to work (should enable log level DEBUG)
+CONFIG_LOG_DEFAULT_LEVEL_INFO=n
+CONFIG_LOG_DEFAULT_LEVEL=4


### PR DESCRIPTION
Our training had a big revamp: https://github.com/esp-rs/espressif-trainings/pull/152 and now the Dockerfile from the training [gets published in dockerhub](https://hub.docker.com/r/espressif/rust-std-training). 

I will try to create a project for the exercise and solution for all the projects of the training and link them in the training content.