### PR TITLE
Allow changing the name of the project in Cargo.toml

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.66.0.0
+FROM espressif/idf-rust:all_1.68.0.0
 
 USER esp
 ENV USER=esp

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -26,6 +26,8 @@ esac
 
 cd ${PROJECT_NAME}
 mkdir -p output
+PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
+PROJECT_NAME_UNDERSCORE=${PROJECT_NAME//-/_}
 
 if [ "$(find ${HOME}/build-in -name '*.rs')" ]; then
     cp ${HOME}/build-in/*.rs src
@@ -33,10 +35,9 @@ fi
 
 if [ -f ${HOME}/build-in/Cargo.toml ]; then
     cp ${HOME}/build-in/Cargo.toml Cargo.toml
+    sed -i 's/^name = ".*"/name = "'${PROJECT_NAME_UNDERSCORE}'"/' Cargo.toml
 fi
 
-PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
-PROJECT_NAME_UNDERSCORE=${PROJECT_NAME//-/_}
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
 python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME_UNDERSCORE} -o ${HOME}/build-out/project.bin

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -35,7 +35,7 @@ fi
 
 if [ -f ${HOME}/build-in/Cargo.toml ]; then
     cp ${HOME}/build-in/Cargo.toml Cargo.toml
-    sed -i 's/^name = ".*"/name = "'${PROJECT_NAME_UNDERSCORE}'"/' Cargo.toml
+    sed -i 's/^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"']\([[:space:]]*\)$/\nname = "'${PROJECT_NAME_UNDERSCORE}'"/' Cargo.toml
 fi
 
 cargo audit


### PR DESCRIPTION
Before, if a user modified the "name" property of Cargo.toml, the build would fail. Now, the name provided by the user will be replaced by the correct one and the build wont fail.

Also updated the Xtensa Rust version