### PR TITLE
Update cargo generate prompts for std builders

### DIFF
--- a/rust-std-esp32/Dockerfile
+++ b/rust-std-esp32/Dockerfile
@@ -3,7 +3,7 @@ FROM espressif/idf-rust:esp32_v4.4_1.66.0.0
 # Install cargo-generate
 USER esp
 ENV USER=esp
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32 --define espidfver=v4.4 --define std=true --define devcontainer=false --define hal="Yes (default features)" \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project -d mcu=esp32 -d defaults=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 

--- a/rust-std-esp32c3/Dockerfile
+++ b/rust-std-esp32c3/Dockerfile
@@ -3,7 +3,7 @@ FROM espressif/idf-rust:esp32c3_v4.4_1.66.0.0
 # Install cargo-generate
 USER esp
 ENV USER=esp
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32c3 --define espidfver=v4.4 --define std=true --define devcontainer=false --define hal="Yes (default features)" \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project -d mcu=esp32c3 -d defaults=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 ADD assets rust-project/assets

--- a/rust-std-esp32s2/Dockerfile
+++ b/rust-std-esp32s2/Dockerfile
@@ -3,7 +3,7 @@ FROM espressif/idf-rust:esp32s2_v4.4_1.66.0.0
 # Install cargo-generate
 USER esp
 ENV USER=esp
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32s2 --define espidfver=v4.4 --define std=true --define devcontainer=false --define hal="Yes (default features)" \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project -d mcu=esp32s2 -d defaults=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 

--- a/rust-std-esp32s3/Dockerfile
+++ b/rust-std-esp32s3/Dockerfile
@@ -3,7 +3,7 @@ FROM espressif/idf-rust:esp32s3_v4.4_1.66.0.0
 # Install cargo-generate
 USER esp
 ENV USER=esp
-RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project --define mcu=esp32s3 --define espidfver=v4.4 --define std=true --define devcontainer=false --define hal="Yes (default features)" \
+RUN cargo generate --vcs none --git https://github.com/esp-rs/esp-idf-template cargo --name rust-project -d mcu=esp32s3 -d defaults=true \
     && rm rust-project/Cargo.toml
 COPY Cargo.toml rust-project/Cargo.toml
 


### PR DESCRIPTION
We've just updated `esp-idf-template` and we added a prompt for newbies which saves some more detailed prompts. For more details see: https://github.com/esp-rs/esp-idf-template/issues/95 and https://github.com/esp-rs/esp-idf-template/pull/100 for more details.

This also makes maintaining the builders easier, as we do not need to edit the builder for every prompt that we add/edit since every prompt will use its default.