### PR TITLE
Update dependencies of  rust-training-esp32c3

### DIFF
--- a/rust-training-esp32c3/Cargo.toml
+++ b/rust-training-esp32c3/Cargo.toml
@@ -17,16 +17,16 @@ default = ["native"]
 native = ["esp-idf-sys/native"]
 
 [dependencies]
-anyhow = "=1.0.69"
+anyhow = "=1.0.71"
 embedded-hal = "=0.2.7"
-embedded-svc = "=0.24.0"
-esp-idf-hal = "=0.40.1"
-esp-idf-svc = { version = "=0.45.0", features = ["experimental", "alloc"] }
-esp-idf-sys = { version = "=0.32.1", features = ["binstart"] }
+embedded-svc = "=0.25.0"
+esp-idf-hal = "=0.41.1"
+esp-idf-svc = { version = "=0.46.0", features = ["experimental", "alloc"] }
+esp-idf-sys = { version = "=0.33.0", features = ["binstart"] }
 get-uuid = { path = "../../common/lib/get-uuid" }
 icm42670 = "=0.1.1"
 lis3dh = "=0.4.2"
-log = "=0.4.17"
+log = "=0.4.18"
 mqtt-messages = { path = "../../common/lib/mqtt-messages" }
 rgb-led = { path = "../../common/lib/rgb-led" }
 shared-bus = "=0.2.5"
@@ -36,6 +36,6 @@ wifi = { path = "../../common/lib/wifi" }
 
 
 [build-dependencies]
-anyhow = "=1.0.69"
-embuild = "=0.31.1"
+anyhow = "=1.0.71"
+embuild = "=0.31.2"
 toml-cfg = "=0.1.3"


### PR DESCRIPTION
This should fix the wokwi-builder.
CI Run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/5199380650