### PR TITLE
Run cargo-audit for std

### DIFF
--- a/rust-std-esp/compile.sh
+++ b/rust-std-esp/compile.sh
@@ -36,6 +36,7 @@ if [ -f ${HOME}/build-in/Cargo.toml ]; then
     sed -i 's/^[[:space:]]*name[[:space:]]*=[[:space:]]*["'"'"']\([^"'"'"']*\)["'"'"']\([[:space:]]*\)$/\nname = "'${PROJECT_NAME}'"/' Cargo.toml
 fi
 
+cargo audit
 cargo build --release --out-dir output -Z unstable-options
 python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME} -o ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf


### PR DESCRIPTION
In order to fix #47 I created https://github.com/esp-rs/rust-build/pull/227 where I added `openssl` as a dependency. 