### PR TITLE
Install cargo-audit with Cargo

### DIFF
--- a/rust-nostd-avr/Dockerfile
+++ b/rust-nostd-avr/Dockerfile
@@ -29,11 +29,7 @@ RUN cargo --version
 RUN rustup show
 
 # Install extra crates
-RUN cargo install cargo-audit && \
-    GENERATE_VERSION=$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)  && \
-    curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o "${HOME}/.cargo/bin/cargo-generate.tar.gz" && \
-    tar xf "${HOME}/.cargo/bin/cargo-generate.tar.gz" -C ${HOME}/.cargo/bin && \
-    chmod u+x "${HOME}/.cargo/bin/cargo-generate"
+RUN cargo install cargo-audit cargo-generate
 
 # Generate project templates
 RUN cargo generate -a Rahix/avr-hal-template --name rust-project-uno --vcs none --silent -d board="Arduino Uno"

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -8,9 +8,7 @@ USER esp
 ENV USER=esp
 
 # Install extra crates
-RUN curl -L "https://github.com/rustsec/rustsec/releases/download/cargo-audit/v0.17.6/cargo-audit-x86_64-unknown-linux-gnu-v0.17.6.tgz" -o "${HOME}/.cargo/bin/cargo-audit.tgz" && \
-    tar xf "${HOME}/.cargo/bin/cargo-audit.tgz" -C ${HOME}/.cargo/bin --strip-components 1 && \
-    chmod u+x "${HOME}/.cargo/bin/cargo-audit" && \
+RUN cargo install cargo-audit && \
     GENERATE_VERSION=$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)  && \
     curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o "${HOME}/.cargo/bin/cargo-generate.tar.gz" && \
     tar xf "${HOME}/.cargo/bin/cargo-generate.tar.gz" -C ${HOME}/.cargo/bin && \


### PR DESCRIPTION
After doing some testing, I was not able to install cargo-audit with artifacts of the GH releases as it generates a lot of issues with openSSL. This seems to work: https://github.com/SergioGasquez/wokwi-builders/actions/runs/5666221085