### PR TITLE
Update Xtensa Rust and use espflash

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.71.0.1
+FROM espressif/idf-rust:all_1.72.0.0
 
 USER esp
 ENV USER=esp
@@ -24,7 +24,6 @@ RUN find . -name "config.toml" -type f -exec sed -i 's/build-std = \["core"\]/bu
 # Copy utility scripts and setup
 COPY compile.sh /home/esp/
 RUN mkdir -p /home/esp/build-in /home/esp/build-out
-RUN pip3 install esptool
 
 # Prebuild the template project for all targets, to test the container.
 # We remove the target directory to reduce the image size.

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -25,7 +25,6 @@ esac
 cd ${PROJECT_NAME}
 mkdir -p output
 PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
-PROJECT_NAME_UNDERSCORE=${PROJECT_NAME//-/_}
 
 if [ "$(find ${HOME}/build-in -name '*.rs')" ]; then
     cp ${HOME}/build-in/*.rs src
@@ -38,5 +37,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME_UNDERSCORE} -o ${HOME}/build-out/project.bin
-cp output/${PROJECT_NAME_UNDERSCORE} ${HOME}/build-out/project.elf
+python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME} -o ${HOME}/build-out/project.bin
+cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -37,5 +37,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME} -o ${HOME}/build-out/project.bin
+espflash save-image --chip esp32 --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -25,6 +25,7 @@ esac
 cd ${PROJECT_NAME}
 mkdir -p output
 PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
+WOKWI_MCU_NO_DASH="${WOKWI_MCU//-/}"
 
 if [ "$(find ${HOME}/build-in -name '*.rs')" ]; then
     cp ${HOME}/build-in/*.rs src
@@ -37,5 +38,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-espflash save-image --chip ${WOKWI_MCU} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
+espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-std-esp/Dockerfile
+++ b/rust-std-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.71.0.1
+FROM espressif/idf-rust:all_1.72.0.0
 
 USER esp
 ENV USER=esp
@@ -22,7 +22,6 @@ RUN cargo generate --vcs none esp-rs/esp-idf-template cargo --name rust-project-
 COPY compile.sh /home/esp/
 ADD assets /home/esp/assets
 RUN mkdir -p /home/esp/build-in /home/esp/build-out
-RUN pip3 install esptool
 
 # Prebuild the template project for all targets - currently disabled to reduce the image size.
 # We remove the target directory to reduce the image size.

--- a/rust-std-esp/compile.sh
+++ b/rust-std-esp/compile.sh
@@ -38,5 +38,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-espflash save-image --chip esp32 --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
+espflash save-image --chip ${WOKWI_MCU} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-std-esp/compile.sh
+++ b/rust-std-esp/compile.sh
@@ -38,5 +38,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB ${PROJECT_ROOT}/output/${PROJECT_NAME} -o ${HOME}/build-out/project.bin
+espflash save-image --chip esp32 --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-std-esp/compile.sh
+++ b/rust-std-esp/compile.sh
@@ -26,6 +26,7 @@ esac
 cd ${PROJECT_NAME}
 mkdir -p output
 PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
+WOKWI_MCU_NO_DASH="${WOKWI_MCU//-/}"
 
 if [ "$(find ${HOME}/build-in -name '*.rs')" ]; then
     cp ${HOME}/build-in/*.rs src
@@ -38,5 +39,5 @@ fi
 
 cargo audit
 cargo build --release --out-dir output -Z unstable-options
-espflash save-image --chip ${WOKWI_MCU} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
+espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf

--- a/rust-training-esp32c3/compile.sh
+++ b/rust-training-esp32c3/compile.sh
@@ -15,5 +15,5 @@ if [ -f ${HOME}/build-in/imc42670p.rs ]; then
     cat ${HOME}/build-in/imc42670p.rs >src/imc42670p.rs
 fi
 cargo build --offline --release
-python3 -m esptool --chip ${WOKWI_MCU} elf2image --flash_size 4MB target/riscv32imc-esp-espidf/release/hardware-check -o ${HOME}/build-out/project.bin
+espflash save-image --chip esp32 --flash-size 4mb target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.bin
 cp target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.elf

--- a/rust-training-esp32c3/compile.sh
+++ b/rust-training-esp32c3/compile.sh
@@ -15,5 +15,5 @@ if [ -f ${HOME}/build-in/imc42670p.rs ]; then
     cat ${HOME}/build-in/imc42670p.rs >src/imc42670p.rs
 fi
 cargo build --offline --release
-espflash save-image --chip esp32 --flash-size 4mb target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.bin
+espflash save-image --chip esp32c3 --flash-size 4mb target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.bin
 cp target/riscv32imc-esp-espidf/release/hardware-check ${HOME}/build-out/project.elf


### PR DESCRIPTION
Updates Xtensa Rust version to 1.72
Since https://github.com/esp-rs/rust-build/pull/233 we no longer have python3 installed in the docker image, but `espflash` is installed, so I switched to use it instead of installing `esptool`.

Successful CI run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/6377579127