### PR TITLE
Update base images for esp-rs builders

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.73.0.0
+FROM espressif/idf-rust:all_1.75.0.0
 
 USER esp
 ENV USER=esp

--- a/rust-std-esp/Dockerfile
+++ b/rust-std-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.73.0.0
+FROM espressif/idf-rust:all_1.75.0.0
 
 USER esp
 ENV USER=esp


### PR DESCRIPTION
Since `std` builder MSRV is now 1.75.

Successful CI run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/7697310220
