### PR TITLE
Update base images

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.75.0.0
+FROM espressif/idf-rust:all_1.76.0.1
 
 USER esp
 ENV USER=esp

--- a/rust-std-esp/Dockerfile
+++ b/rust-std-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.75.0.0
+FROM espressif/idf-rust:all_1.76.0.1
 
 USER esp
 ENV USER=esp


### PR DESCRIPTION
Update `rustc` version.  CI run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/8232603256
std fails because of https://github.com/wokwi/wokwi-builders/issues/61