### PR TITLE
Fix esp builders

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,10 +1,10 @@
-FROM espressif/idf-rust:all_1.77.0.0
+FROM espressif/idf-rust:all_1.78.0.0
 
 USER esp
 ENV USER=esp
 
 # Install extra crates
-RUN cargo install cargo-audit@0.17.6 && \
+RUN cargo install cargo-audit && \
     GENERATE_VERSION=$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)  && \
     curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o "${HOME}/.cargo/bin/cargo-generate.tar.gz" && \
     tar xf "${HOME}/.cargo/bin/cargo-generate.tar.gz" -C ${HOME}/.cargo/bin && \

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -13,12 +13,12 @@ RUN cargo install cargo-audit && \
     chmod u+x "${HOME}/.cargo/bin/rnamer"
 
 # Generate project templates
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32 -d mcu=esp32 -d advanced=false
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32c3 -d mcu=esp32c3 -d advanced=false
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32c6 -d mcu=esp32c6 -d advanced=false
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32h2 -d mcu=esp32h2 -d advanced=false
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32s2 -d mcu=esp32s2 -d advanced=false
-RUN cargo generate --vcs none esp-rs/esp-template --name rust-project-esp32s3 -d mcu=esp32s3 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32 -d mcu=esp32 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32c3 -d mcu=esp32c3 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32c6 -d mcu=esp32c6 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32h2 -d mcu=esp32h2 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32s2 -d mcu=esp32s2 -d advanced=false
+RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32s3 -d mcu=esp32s3 -d advanced=false
 
 # Add alloc to the build-std property
 RUN find . -name "config.toml" -type f -exec sed -i 's/build-std = \["core"\]/build-std = \["alloc", "core"\]/g' {} +

--- a/rust-nostd-esp/config.toml
+++ b/rust-nostd-esp/config.toml
@@ -4,7 +4,6 @@ runner = "espflash flash --monitor"
 
 [build]
 rustflags = [
-  "-C", "link-arg=-Tlinkall.x",
   "-C", "force-frame-pointers",
 ]
 

--- a/rust-std-esp/Dockerfile
+++ b/rust-std-esp/Dockerfile
@@ -1,10 +1,10 @@
-FROM espressif/idf-rust:all_1.77.0.0
+FROM espressif/idf-rust:all_1.78.0.0
 
 USER esp
 ENV USER=esp
 
 # Install extra crates
-RUN cargo install cargo-audit@0.17.6 && \
+RUN cargo install cargo-audit && \
     GENERATE_VERSION=$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)  && \
     curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o "${HOME}/.cargo/bin/cargo-generate.tar.gz" && \
     tar xf "${HOME}/.cargo/bin/cargo-generate.tar.gz" -C ${HOME}/.cargo/bin && \


### PR DESCRIPTION
- Update base images to 1.78
- Unpin `cargo-audit` version
- Add `-a` flag to `cargo-generate` command

Successful CI run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/9030300476