### PR TITLE
Fix no_std esp builds

### DIFF
--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -6,23 +6,29 @@ set -e
 case ${WOKWI_MCU} in
 "esp32")
     PROJECT_NAME="rust-project-esp32"
+    TARGET="xtensa-esp32-none-elf"
     ;;
 "esp32-c3")
     PROJECT_NAME="rust-project-esp32c3"
+    TARGET="riscv32imc-unknown-none-elf"
     rm ${PROJECT_NAME}/.cargo/config.toml
     cp ${HOME}/config.toml ${PROJECT_NAME}/.cargo/config.toml
     ;;
 "esp32-c6")
     PROJECT_NAME="rust-project-esp32c6"
+    TARGET="riscv32imac-unknown-none-elf"
     ;;
 "esp32-h2")
     PROJECT_NAME="rust-project-esp32h2"
+    TARGET="riscv32imac-unknown-none-elf"
     ;;
 "esp32-s2")
     PROJECT_NAME="rust-project-esp32s2"
+    TARGET="xtensa-esp32s2-none-elf"
     ;;
 "esp32-s3")
     PROJECT_NAME="rust-project-esp32s3"
+    TARGET="xtensa-esp32s3-none-elf"
     ;;
 *)
     echo "Missing or invalid WOKWI_MCU environment variable"
@@ -45,6 +51,6 @@ if [ -f ${HOME}/build-in/Cargo.toml ]; then
 fi
 
 cargo audit
-cargo build --release --out-dir output -Z unstable-options
-espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb ${PROJECT_ROOT}/output/${PROJECT_NAME} ${HOME}/build-out/project.bin
-cp output/${PROJECT_NAME} ${HOME}/build-out/project.elf
+cargo build --release
+espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.bin
+cp target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.elf


### PR DESCRIPTION
We switched the template to use [`stable` channel](https://github.com/esp-rs/esp-template/pull/167) and in CI we were using some unstable flags that required `nightly`.

Sorry for taking this long to fix it, it slipped under my radar.

Successful CI run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/10919171387