### PR TITLE
Use esp-generate in no_std builder

### DIFF
--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.80.0.0
+FROM espressif/idf-rust:all_1.82.0.3
 
 USER esp
 ENV USER=esp

--- a/rust-nostd-esp/Dockerfile
+++ b/rust-nostd-esp/Dockerfile
@@ -4,21 +4,17 @@ USER esp
 ENV USER=esp
 
 # Install extra crates
-RUN cargo install cargo-audit && \
-    GENERATE_VERSION=$(git ls-remote --refs --sort="version:refname" --tags "https://github.com/cargo-generate/cargo-generate" | cut -d/ -f3- | tail -n1)  && \
-    curl -L "https://github.com/cargo-generate/cargo-generate/releases/latest/download/cargo-generate-${GENERATE_VERSION}-x86_64-unknown-linux-gnu.tar.gz" -o "${HOME}/.cargo/bin/cargo-generate.tar.gz" && \
-    tar xf "${HOME}/.cargo/bin/cargo-generate.tar.gz" -C ${HOME}/.cargo/bin && \
-    chmod u+x "${HOME}/.cargo/bin/cargo-generate" && \
+RUN cargo install cargo-audit && cargo install esp-generate && \
     curl -L "https://github.com/SergioGasquez/rnamer/releases/latest/download/rnamer-x86_64-unknown-linux-gnu" -o "${HOME}/.cargo/bin/rnamer" && \
     chmod u+x "${HOME}/.cargo/bin/rnamer"
 
 # Generate project templates
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32 -d mcu=esp32 -d advanced=false
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32c3 -d mcu=esp32c3 -d advanced=false
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32c6 -d mcu=esp32c6 -d advanced=false
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32h2 -d mcu=esp32h2 -d advanced=false
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32s2 -d mcu=esp32s2 -d advanced=false
-RUN cargo generate -a --vcs none esp-rs/esp-template --name rust-project-esp32s3 -d mcu=esp32s3 -d advanced=false
+RUN esp-generate --headless --chip=esp32 rust-project-esp32
+RUN esp-generate --headless --chip=esp32c3 rust-project-esp32c3
+RUN esp-generate --headless --chip=esp32c6 rust-project-esp32c6
+RUN esp-generate --headless --chip=esp32h2 rust-project-esp32h2
+RUN esp-generate --headless --chip=esp32s2 rust-project-esp32s2
+RUN esp-generate --headless --chip=esp32s3 rust-project-esp32s3
 
 # Add alloc to the build-std property
 RUN find . -name "config.toml" -type f -exec sed -i 's/build-std = \["core"\]/build-std = \["alloc", "core"\]/g' {} +

--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -11,8 +11,6 @@ case ${WOKWI_MCU} in
 "esp32-c3")
     PROJECT_NAME="rust-project-esp32c3"
     TARGET="riscv32imc-unknown-none-elf"
-    rm ${PROJECT_NAME}/.cargo/config.toml
-    cp ${HOME}/config.toml ${PROJECT_NAME}/.cargo/config.toml
     ;;
 "esp32-c6")
     PROJECT_NAME="rust-project-esp32c6"
@@ -37,8 +35,6 @@ case ${WOKWI_MCU} in
 esac
 
 cd ${PROJECT_NAME}
-mkdir -p output
-PROJECT_ROOT="${HOME}/${PROJECT_NAME}"
 WOKWI_MCU_NO_DASH="${WOKWI_MCU//-/}"
 
 if [ "$(find ${HOME}/build-in -name '*.rs')" ]; then
@@ -52,5 +48,5 @@ fi
 
 cargo audit
 cargo build --release
-espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.bin
-cp target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.elf
+espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb target/${TARGET}/release/main ${HOME}/build-out/project.bin
+cp target/${TARGET}/release/main ${HOME}/build-out/project.elf

--- a/rust-std-esp/Dockerfile
+++ b/rust-std-esp/Dockerfile
@@ -1,4 +1,4 @@
-FROM espressif/idf-rust:all_1.80.0.0
+FROM espressif/idf-rust:all_1.82.0.3
 
 USER esp
 ENV USER=esp

--- a/rust-training-esp32c3/Cargo.toml
+++ b/rust-training-esp32c3/Cargo.toml
@@ -31,8 +31,6 @@ shared-bus = "=0.3.1"
 shtcx = "=0.11.0"
 toml-cfg = "=0.1.3"
 wifi = { path = "../../common/lib/wifi" }
-cc = "1.1.31" # Can be removed once https://github.com/rust-lang/cmake-rs/pull/225 is merged
-
 
 [build-dependencies]
 anyhow = "=1.0.86"

--- a/rust-training-esp32c3/Cargo.toml
+++ b/rust-training-esp32c3/Cargo.toml
@@ -31,6 +31,8 @@ shared-bus = "=0.3.1"
 shtcx = "=0.11.0"
 toml-cfg = "=0.1.3"
 wifi = { path = "../../common/lib/wifi" }
+cc = "1.1.31" # Can be removed once https://github.com/rust-lang/cmake-rs/pull/225 is merged
+
 
 [build-dependencies]
 anyhow = "=1.0.86"


### PR DESCRIPTION
- Replace esp-template for esp-generate
- Use latest base image

CI Run: https://github.com/SergioGasquez/wokwi-builders/actions/runs/11892658431/job/33135976000
