### PR TITLE
Remove cargo-update

### DIFF
--- a/rust-nostd-esp/compile.sh
+++ b/rust-nostd-esp/compile.sh
@@ -47,7 +47,6 @@ if [ -f ${HOME}/build-in/Cargo.toml ]; then
 fi
 
 cargo audit
-cargo update
 cargo build --release
 espflash save-image --chip ${WOKWI_MCU_NO_DASH} --flash-size 4mb target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.bin
 cp target/${TARGET}/release/${PROJECT_NAME} ${HOME}/build-out/project.elf


### PR DESCRIPTION
For some reasons, the builds are failing in wokwi.com, but in my CI pipeline they are passing: https://github.com/SergioGasquez/wokwi-projects/actions.

Also, using the current wokwi-buidler locally, works fine. But when using it on wokwi.com, fails. I think the error was related to the `cargo update` and its no longer needed, so lets give it a shot.

```
[0m[0m[1m[32m    Fetching[0m advisory database from `https://github.com/RustSec/advisory-db.git`
[0m[0m[1m[32m      Loaded[0m 798 security advisories (from /home/esp/.cargo/advisory-db)
[0m[0m[1m[32m    Updating[0m crates.io index
[0m[0m[1m[32m    Scanning[0m Cargo.lock for vulnerabilities (106 crate dependencies)
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve delegate from crates.io index: registry: EOF while parsing a string at line 1 column 592
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve embassy-sync from crates.io index: registry: EOF while parsing an object at line 1 column 1043
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve esp-hal from crates.io index: registry: EOF while parsing a string at line 1 column 6342
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve esp32 from crates.io index: registry: EOF while parsing a string at line 1 column 176
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve esp32c2 from crates.io index: registry: EOF while parsing a string at line 1 column 540
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve evalexpr from crates.io index: registry: EOF while parsing a string at line 1 column 892
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve jiff from crates.io index: registry: EOF while parsing a string at line 1 column 827
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve litrs from crates.io index: registry: EOF while parsing a string at line 1 column 49
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve proc-macro2 from crates.io index: registry: EOF while parsing a value at line 1 column 131
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve riscv-rt-macros from crates.io index: registry: EOF while parsing an object at line 1 column 417
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve strum_macros from crates.io index: registry: EOF while parsing a string at line 1 column 206
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve syn from crates.io index: registry: EOF while parsing a string at line 1 column 438
[0m[0m[1m[31merror:[0m couldn't check if the package is yanked: registry: Failed to retrieve windows-targets from crates.io index: registry: EOF while parsing a string at line 1 column 1586
[0m[0m[1m[33mwarning:[0m 1 allowed warning found
    Updating crates.io index
error: failed to select a version for the requirement `esp-hal = "^1.0.0-rc.0"`
candidate versions found which didn't match: 1.0.0-beta.0, 0.23.1, 0.23.0, ...
location searched: crates.io index
required by package `rust-project-esp32 v0.1.0 (/home/esp/rust-project-esp32)`
if you are looking for the prerelease package it needs to be specified explicitly
    esp-hal = { version = "1.0.0-beta.0" }

Error: Process exited with 101
```